### PR TITLE
Fix deprecated string interpolation

### DIFF
--- a/php/TreeFetcher.php
+++ b/php/TreeFetcher.php
@@ -71,7 +71,7 @@ class PHPStanVSCodeTreeFetcher implements Rule {
 			$remainingPositions -= 1;
 			$matches = [];
 			$name = $isVar ? '\$' . $varName : $varName;
-			preg_match("/${name}[^a-zA-Z0-9_]/", $line, $matches, PREG_OFFSET_CAPTURE, $offset + 1);
+			preg_match("/{$name}[^a-zA-Z0-9_]/", $line, $matches, PREG_OFFSET_CAPTURE, $offset + 1);
 			if (!$matches[0]) {
 				$offset = false;
 				break;


### PR DESCRIPTION
Under PHP 8.2, the old syntax gives a deprecation warning. More information: https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated