### PR TITLE
Fix paths not using mapping when scanning project

### DIFF
--- a/server/src/lib/phpstan/configManager.ts
+++ b/server/src/lib/phpstan/configManager.ts
@@ -32,7 +32,7 @@ export class ConfigurationManager {
 
 	public static async getPathMapper(
 		config: ClassConfig
-	): Promise<(filePath: string) => string> {
+	): Promise<(filePath: string, inverse?: boolean) => string> {
 		const pathMapping =
 			(
 				await getConfiguration(
@@ -41,12 +41,15 @@ export class ConfigurationManager {
 				)
 			).paths ?? {};
 
-		return (filePath: string) => {
+		return (filePath: string, inverse: boolean = false) => {
 			if (Object.keys(pathMapping).length === 0) {
 				return filePath;
 			}
 			const expandedFilePath = filePath.replace(/^~/, os.homedir());
-			for (const [from, to] of Object.entries(pathMapping)) {
+			for (const [fromPath, toPath] of Object.entries(pathMapping)) {
+				const [from, to] = inverse
+					? [toPath, fromPath]
+					: [fromPath, toPath];
 				const expandedFromPath = from.replace(/^~/, os.homedir());
 				if (expandedFilePath.startsWith(expandedFromPath)) {
 					return expandedFilePath.replace(

--- a/server/src/lib/phpstan/configManager.ts
+++ b/server/src/lib/phpstan/configManager.ts
@@ -26,6 +26,13 @@ export class ConfigurationManager {
 		config: ClassConfig,
 		filePath: string
 	): Promise<string> {
+		const pathMapper = await this.getPathMapper(config);
+		return pathMapper(filePath);
+	}
+
+	public static async getPathMapper(
+		config: ClassConfig
+	): Promise<(filePath: string) => string> {
 		const pathMapping =
 			(
 				await getConfiguration(
@@ -33,20 +40,23 @@ export class ConfigurationManager {
 					config.getWorkspaceFolder
 				)
 			).paths ?? {};
-		if (Object.keys(pathMapping).length === 0) {
-			return filePath;
-		}
-		const expandedFilePath = filePath.replace(/^~/, os.homedir());
-		for (const [from, to] of Object.entries(pathMapping)) {
-			const expandedFromPath = from.replace(/^~/, os.homedir());
-			if (expandedFilePath.startsWith(expandedFromPath)) {
-				return expandedFilePath.replace(
-					expandedFromPath,
-					to.replace(/^~/, os.homedir())
-				);
+
+		return (filePath: string) => {
+			if (Object.keys(pathMapping).length === 0) {
+				return filePath;
 			}
-		}
-		return filePath;
+			const expandedFilePath = filePath.replace(/^~/, os.homedir());
+			for (const [from, to] of Object.entries(pathMapping)) {
+				const expandedFromPath = from.replace(/^~/, os.homedir());
+				if (expandedFilePath.startsWith(expandedFromPath)) {
+					return expandedFilePath.replace(
+						expandedFromPath,
+						to.replace(/^~/, os.homedir())
+					);
+				}
+			}
+			return filePath;
+		};
 	}
 
 	private async _fileIfExists(filePath: string): Promise<string | null> {

--- a/server/src/lib/phpstan/runner.ts
+++ b/server/src/lib/phpstan/runner.ts
@@ -390,6 +390,9 @@ export class PHPStanRunner implements Disposable {
 		if (this._cancelled) {
 			return ReturnResult.canceled();
 		}
+		const pathMapper = await ConfigurationManager.getPathMapper(
+			this._config
+		);
 
 		// Get args
 		const args = await this._getArgs(config, {
@@ -411,7 +414,7 @@ export class PHPStanRunner implements Disposable {
 				normalized[
 					URI.from({
 						scheme: 'file',
-						path: filePath,
+						path: pathMapper(filePath),
 					}).toString()
 				] = parsed[filePath];
 			}

--- a/server/src/lib/phpstan/runner.ts
+++ b/server/src/lib/phpstan/runner.ts
@@ -414,7 +414,7 @@ export class PHPStanRunner implements Disposable {
 				normalized[
 					URI.from({
 						scheme: 'file',
-						path: pathMapper(filePath),
+						path: pathMapper(filePath, true),
 					}).toString()
 				] = parsed[filePath];
 			}


### PR DESCRIPTION
Fixes #27

Paths were not being mapped when scanning a project the same way they were when scanning a single file. This PR fixes that by adding a method that returns a (synchronous) mapping function, which can then be used to map one or many paths using the same mapping config (retrieved asynchronously).