### PR TITLE
Show tip as part of the error message

### DIFF
--- a/client/src/notificationReceivers/errorManager.ts
+++ b/client/src/notificationReceivers/errorManager.ts
@@ -8,6 +8,7 @@ interface PHPStanError {
 	lineNumber: number | null;
 	ignorable: boolean;
 	identifier: string | null;
+	tip: string | null;
 }
 
 export class ErrorManager implements Disposable, vscode.CodeActionProvider {
@@ -68,6 +69,7 @@ export class ErrorManager implements Disposable, vscode.CodeActionProvider {
 								lineNumber: null,
 								ignorable: false,
 								identifier: null,
+								tip: null,
 							})
 						),
 					]);
@@ -97,7 +99,18 @@ export class ErrorManager implements Disposable, vscode.CodeActionProvider {
 		range: vscode.Range,
 		error: PHPStanError
 	): vscode.Diagnostic {
-		const diagnostic = new vscode.Diagnostic(range, error.message);
+		const tip = error.tip
+			? '\n💡 ' +
+				error.tip
+					.split('\n')
+					.map((l) => l.trim())
+					.join(' ')
+			: '';
+
+		const diagnostic = new vscode.Diagnostic(
+			range,
+			`${error.message}${tip}`
+		);
 		diagnostic.source = 'PHPStan';
 		if (error.identifier) {
 			diagnostic.code = {

--- a/server/src/lib/phpstan/check.ts
+++ b/server/src/lib/phpstan/check.ts
@@ -60,6 +60,7 @@ export class PHPStanCheck implements AsyncDisposable {
 					lineNumber: message.line,
 					ignorable: message.ignorable,
 					identifier: message.identifier ?? null,
+					tip: message.tip ?? null,
 				})),
 			];
 		}
@@ -274,6 +275,7 @@ export interface ReportedErrors {
 			lineNumber: number | null;
 			ignorable: boolean;
 			identifier: string | null;
+			tip: string | null;
 		}[]
 	>;
 	notFileSpecificErrors: string[];

--- a/server/src/lib/phpstan/pro/proErrorManager.ts
+++ b/server/src/lib/phpstan/pro/proErrorManager.ts
@@ -220,6 +220,7 @@ export class PHPStanProErrorManager implements Disposable {
 				lineNumber: fileError.line,
 				ignorable: fileError.ignorable,
 				identifier: fileError.identifier ?? null,
+				tip: fileError.tip ?? null,
 			});
 		}
 		void this._classConfig.connection.sendNotification(errorNotification, {
@@ -248,6 +249,7 @@ interface ReportedError {
 	message: string;
 	ignorable: boolean;
 	identifier: string | null;
+	tip: string | null;
 }
 
 interface ProReportedErrors {

--- a/server/src/lib/phpstan/processRunner.ts
+++ b/server/src/lib/phpstan/processRunner.ts
@@ -33,6 +33,7 @@ export interface PHPStanCheckResult {
 				ignorable: boolean;
 				line: number;
 				message: string;
+				tip?: string;
 			}[];
 		}
 	>;


### PR DESCRIPTION
Couldn't really find a better place to display them.

![screenshot-2024-08-03T16 41 29@2x](https://github.com/user-attachments/assets/c441e3f2-d7b9-4e52-8f2f-1ee7dba0ec2b)

Didn't test with PHPStan Pro.