### PR TITLE
Fix description of `enableLanguageServer` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ https://user-images.githubusercontent.com/5385012/188924277-c9392477-9bd6-40b1-9
 
 -   `phpstan.enabled` - whether to enable the on-save checker (defaults to `true`)
 -   `phpstan.enableStatusBar` - whether to show a statusbar entry while performing the check (defaults to `true`)
--   `phpstan.enableLanguageServer` - Whether to enable the language server that provides on-hover information. Disable this if you're using a custom PHPStan binary that runs on another filesystem (such as Docker) and you're running into issues (defaults to `true`)
+-   `phpstan.enableLanguageServer` - Whether to enable the language server that provides on-hover information. Disable this if you're using a custom PHPStan binary that runs on another filesystem (such as Docker) and you're running into issues (defaults to `false`)
 -   `phpstan.showProgress` - whether to show the progress bar when performing a single-file check (defaults to `false`)
 -   `phpstan.checkValidity` - Whether to check the validity of PHP code before checking it with PHPStan. This is recommended only if you have autoSave enabled or for some other reason save syntactically invalid code. PHPStan tends to invalidate its cache when checking an invalid file, leading to a slower experience.'. (defaults to `false`)
 


### PR DESCRIPTION
Hi, I am finding this extension to be a great help. Thank you for your work!

I found a mistake in the README. Based on the implementation, it seems that the default value for the `phpstan.enableLanguageServer` option is `false`.

- https://github.com/SanderRonde/phpstan-vscode/blob/v3.1.14/package.json#L127-L131
- https://github.com/SanderRonde/phpstan-vscode/blob/v3.1.14/shared/commands/defs.ts#L166-L173

If there are no problems, please consider merging this change.