### PR TITLE
Update diagnostic range when a file is loaded

### DIFF
--- a/client/src/notificationReceivers/errorManager.ts
+++ b/client/src/notificationReceivers/errorManager.ts
@@ -106,7 +106,11 @@ export class ErrorManager implements Disposable, vscode.CodeActionProvider {
 		error: PHPStanError
 	): vscode.Diagnostic {
 		if (this._diagnosticMap.has(error)) {
-			return this._diagnosticMap.get(error)!;
+			const diagnostic = this._diagnosticMap.get(error)!;
+			if (!diagnostic.range.isEqual(range)) {
+				diagnostic.range = range;
+			}
+			return diagnostic;
 		}
 
 		const tip = error.tip


### PR DESCRIPTION
Mark the whole line (not just the start) even if the file wasn't opened at checking time.

The range for the diagnostic was already recalculated on file open but a cached range was returned. This fix updates the cached range.

Unfortunate side effect: when you click a diagnostic in the "problems" panel, and the range is updated, VS Code counts it as a new unrelated diagnostic and deselects the problem you just clicked. (This already happened when a new check finishes.)