### PR TITLE
Fix error merging: new errors should override stale ones (fixes #150)

### DIFF
--- a/server/src/lib/phpstan/check.ts
+++ b/server/src/lib/phpstan/check.ts
@@ -295,10 +295,10 @@ class PHPStanCheckErrorManager {
 			lastErrors,
 		] of PHPStanCheckErrorManager._lastErrors) {
 			errors.fileSpecificErrors = {
-				...errors.fileSpecificErrors,
 				...(lastErrorConfigFile !== configFile || isPartial
 					? lastErrors.fileSpecificErrors
 					: {}),
+				...errors.fileSpecificErrors,
 			};
 		}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After the fix for #147 (commit `fa0b849`), editing and saving a file would no longer update the inline errors and Problems tab. PHPStan would run successfully (progress bar visible, output correct in the Output panel), but the diagnostics shown in the editor remained unchanged.

## Root Cause

In `PHPStanCheckErrorManager._getErrors`, the spread order when merging errors from multiple config files was incorrect:

```ts
// BEFORE (broken): lastErrors spread last, overwrites new results
errors.fileSpecificErrors = {
    ...errors.fileSpecificErrors,
    ...(lastErrorConfigFile !== configFile || isPartial
        ? lastErrors.fileSpecificErrors
        : {}),
};
```

`lastErrors.fileSpecificErrors` (stale/old errors) was spread **after** `errors.fileSpecificErrors` (the fresh scan results), so for any file appearing in both, the old errors silently overwritten the new ones.

## Fix

Reverse the spread order so new errors take priority over stale ones:

```ts
// AFTER (fixed): new results spread last, take priority
errors.fileSpecificErrors = {
    ...(lastErrorConfigFile !== configFile || isPartial
        ? lastErrors.fileSpecificErrors
        : {}),
    ...errors.fileSpecificErrors,
};
```

This preserves the original intent: merge in errors from other config files (or previous partial scans), but always let the current scan's results win for any file they cover.

Fixes #150
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67dc95c8-1813-4b06-b29d-931bbf1983e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67dc95c8-1813-4b06-b29d-931bbf1983e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

