### PR TITLE
Show actionable error when PHP binary is not found

### DIFF
--- a/server/src/lib/phpstan/processRunner.ts
+++ b/server/src/lib/phpstan/processRunner.ts
@@ -324,6 +324,33 @@ export class PHPStanRunner implements AsyncDisposable {
 					return;
 				}
 
+				// Check for PHP not found (e.g. shebang #!/usr/bin/env php fails)
+				if (
+					getErr().includes('No such file or directory') ||
+					getErr().includes('command not found')
+				) {
+					const errorMsg =
+						'PHPStan: PHP binary not found. Configure the path to PHP using the phpstan.binCommand setting (e.g. ["/path/to/php", "vendor/bin/phpstan"])';
+					if (_onError) {
+						_onError(errorMsg);
+					} else {
+						showError(this._classConfig.connection, errorMsg, [
+							{
+								title: 'Configure binCommand',
+								callback: () => {
+									void executeCommand(
+										this._classConfig.connection,
+										'workbench.action.openSettings',
+										`@ext:${EXTENSION_ID} binCommand`
+									);
+								},
+							},
+						]);
+					}
+					resolve(ReturnResult.error());
+					return;
+				}
+
 				// Try to parse stdout first. Valid JSON in stdout
 				// takes priority over any stderr content (PHPStan may print notices
 				// such as coding-agent instructions to stderr even with


### PR DESCRIPTION
## Summary

- When the PHPStan process fails because PHP is not in `PATH` (e.g. `env: php: No such file or directory`), the extension now shows a specific error message guiding the user to configure `phpstan.binCommand`, along with a button that opens the relevant setting.
- This is a common issue on macOS when VSCode is launched from the GUI rather than the terminal, especially with version managers like mise, asdf, or phpenv that rely on shell PATH configuration.
- Previously, this scenario produced only a generic "process exited with error, see log for details" message with no actionable guidance.

## Changes

`server/src/lib/phpstan/processRunner.ts`:

- Added stderr detection for `No such file or directory` and `command not found` in the `onExit` handler, following the existing pattern used for `Allowed memory size of` and `At least one path must be specified to analyse`.
- Displays the message: *"PHPStan: PHP binary not found. Configure the path to PHP using the phpstan.binCommand setting"* with a **Configure binCommand** button that opens the setting.